### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This MCP server provides a tool to download entire websites using wget. It preserves the website structure and converts links to work locally.
 
+<a href="https://glama.ai/mcp/servers/egcwr79vu2"><img width="380" height="200" src="https://glama.ai/mcp/servers/egcwr79vu2/badge" alt="Google Workspace Server MCP server" /></a>
+
 ## Prerequisites
 
 The server requires `wget` to be installed on your system.


### PR DESCRIPTION
This PR adds a badge for the Google Workspace MCP Server server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/egcwr79vu2"><img width="380" height="200" src="https://glama.ai/mcp/servers/egcwr79vu2/badge" alt="Google Workspace Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.